### PR TITLE
Env update

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - libgfortran=3.0.1
   - matplotlib=3.0.2
   - mkl=2018.0.3
-  - mkl_fft=1.0.4
+  - mkl_fft
   - mkl_random=1.0.1
   - nb_conda
   - nbformat=4.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -69,7 +69,22 @@ dependencies:
   - xlrd=1.1.0
   - xz=5.2.4
   - zlib=1.2.11
-  - py-xgboost==0.72
+  - py-xgboost=0.72
+  - tqdm=4.30.0
+  - statsmodels=0.9.0
+  - cvxpy=1.0.14
+  - graphviz=2.40.1
+  - beautifulsoup4=4.7.1
+  - folium=0.7.0
+  - networkx=2.2
+  - nltk=3.4
+  - gensim=3.4.0
+  - h5py=2.9.0
+  - pil=1.1.7
+  - pyspark=2.4.0
+  - patsy=0.5.1
+  - pydotplus=2.0.2
+  - imbalanced-learn=0.4.3
   - pip:
     - ipynb==0.5.1
     - pytest==3.7

--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - nb_conda
   - nbformat=4.4.0
   - ncurses=6.1
-  - numpy=1.15.0
+  - numpy
   - numpy-base=1.15.0
   - openssl=1.0.2p
   - pandas=0.23.4

--- a/environment.yml
+++ b/environment.yml
@@ -77,7 +77,6 @@ dependencies:
   - nltk=3.4
   - gensim=3.4.0
   - h5py=2.9.0
-  - pil=1.1.7
   - pyspark=2.4.0
   - patsy=0.5.1
   - pydotplus=2.0.2

--- a/environment.yml
+++ b/environment.yml
@@ -70,7 +70,7 @@ dependencies:
   - xz=5.2.4
   - zlib=1.2.11
   - py-xgboost=0.72
-  - tqdm=4.30.0
+  - tqdm
   - statsmodels=0.9.0
   - beautifulsoup4=4.7.1
   - networkx=2.2

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - nbformat=4.4.0
   - ncurses=6.1
   - numpy
-  - numpy-base=1.15.0
+  - numpy-base
   - openssl=1.0.2p
   - pandas=0.23.4
   - parso=0.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -27,9 +27,9 @@ dependencies:
   - libffi=3.2.1
   - libgfortran=3.0.1
   - matplotlib=3.0.2
-  - mkl=2018.0.3
+  - mkl
   - mkl_fft
-  - mkl_random=1.0.1
+  - mkl_random
   - nb_conda
   - nbformat=4.4.0
   - ncurses=6.1

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - libedit=3.1.20170329
   - libffi=3.2.1
   - libgfortran=3.0.1
-  - matplotlib
+  - matplotlib=3.0.2
   - mkl=2018.0.3
   - mkl_fft=1.0.4
   - mkl_random=1.0.1
@@ -54,9 +54,9 @@ dependencies:
   - readline=7.0
   - requests=2.19.1
   - retrying=1.3.3
-  - scikit-learn
-  - scipy
-  - seaborn
+  - scikit-learn=0.20.2
+  - scipy=1.1.0
+  - seaborn=0.9.0
   - setuptools=40.0.0
   - simplegeneric=0.8.1
   - six=1.11.0
@@ -72,10 +72,7 @@ dependencies:
   - py-xgboost=0.72
   - tqdm=4.30.0
   - statsmodels=0.9.0
-  - cvxpy=1.0.14
-  - graphviz=2.40.1
   - beautifulsoup4=4.7.1
-  - folium=0.7.0
   - networkx=2.2
   - nltk=3.4
   - gensim=3.4.0
@@ -84,11 +81,13 @@ dependencies:
   - pyspark=2.4.0
   - patsy=0.5.1
   - pydotplus=2.0.2
-  - imbalanced-learn=0.4.3
   - pip:
     - ipynb==0.5.1
     - pytest==3.7
     - tensorflow==1.6
     - keras==2.2.1
     - obscure==1.0.1
+    - folium
+    - imbalanced-learn
+    - graphviz
 prefix: /anaconda3/envs/learn-env

--- a/windows.yml
+++ b/windows.yml
@@ -22,7 +22,7 @@ dependencies:
   - jupyter_core=4.4.0
   - matplotlib=3.0.2
   - mkl=2018.0.3
-  - mkl_fft=1.0.4
+  - mkl_fft
   - mkl_random=1.0.1
   - nb_conda=2.2.1
   - nbformat=4.4.0

--- a/windows.yml
+++ b/windows.yml
@@ -26,7 +26,7 @@ dependencies:
   - mkl_random=1.0.1
   - nb_conda=2.2.1
   - nbformat=4.4.0
-  - numpy=1.15.0
+  - numpy
   - numpy-base=1.15.0
   - openssl=1.0.2p
   - pandas=0.23.4

--- a/windows.yml
+++ b/windows.yml
@@ -21,9 +21,9 @@ dependencies:
   - jsonschema=2.6.0
   - jupyter_core=4.4.0
   - matplotlib=3.0.2
-  - mkl=2018.0.3
+  - mkl
   - mkl_fft
-  - mkl_random=1.0.1
+  - mkl_random
   - nb_conda=2.2.1
   - nbformat=4.4.0
   - numpy

--- a/windows.yml
+++ b/windows.yml
@@ -60,7 +60,22 @@ dependencies:
   - xlrd=1.1.0
   - xz=5.2.4
   - zlib=1.2.11
-  - py-xgboost==0.72
+  - py-xgboost=0.72
+  - tqdm=4.30.0
+  - statsmodels=0.9.0
+  - cvxpy=1.0.14
+  - graphviz=2.40.1
+  - beautifulsoup4=4.7.1
+  - folium=0.7.0
+  - networkx=2.2
+  - nltk=3.4
+  - gensim=3.4.0
+  - h5py=2.9.0
+  - pil=1.1.7
+  - pyspark=2.4.0
+  - patsy=0.5.1
+  - pydotplus=2.0.2
+  - imbalanced-learn=0.4.3
   - pip:
     - ipynb==0.5.1
     - pytest==3.7

--- a/windows.yml
+++ b/windows.yml
@@ -20,11 +20,11 @@ dependencies:
   - jedi=0.12.1
   - jsonschema=2.6.0
   - jupyter_core=4.4.0
-  - matplotlib
+  - matplotlib=3.0.2
   - mkl=2018.0.3
   - mkl_fft=1.0.4
   - mkl_random=1.0.1
-  - nb_conda
+  - nb_conda=2.2.1
   - nbformat=4.4.0
   - numpy=1.15.0
   - numpy-base=1.15.0
@@ -45,9 +45,9 @@ dependencies:
   - pytz=2018.5
   - requests=2.19.1
   - retrying=1.3.3
-  - scikit-learn
-  - scipy
-  - seaborn
+  - scikit-learn=0.20.2
+  - scipy=1.1.0
+  - seaborn=0.9.0
   - setuptools=40.0.0
   - simplegeneric=0.8.1
   - six=1.11.0

--- a/windows.yml
+++ b/windows.yml
@@ -61,25 +61,23 @@ dependencies:
   - xz=5.2.4
   - zlib=1.2.11
   - py-xgboost=0.72
-  - tqdm=4.30.0
+  - tqdm=4.15.0
   - statsmodels=0.9.0
-  - cvxpy=1.0.14
-  - graphviz=2.40.1
   - beautifulsoup4=4.7.1
-  - folium=0.7.0
   - networkx=2.2
   - nltk=3.4
   - gensim=3.4.0
   - h5py=2.9.0
-  - pil=1.1.7
   - pyspark=2.4.0
   - patsy=0.5.1
   - pydotplus=2.0.2
-  - imbalanced-learn=0.4.3
   - pip:
     - ipynb==0.5.1
     - pytest==3.7
     - tensorflow==1.6
     - keras==2.2.1
     - obscure==1.0.1
+    - folium
+    - imbalanced-learn
+    - graphviz
 prefix: /anaconda3/envs/learn-env

--- a/windows.yml
+++ b/windows.yml
@@ -27,7 +27,7 @@ dependencies:
   - nb_conda=2.2.1
   - nbformat=4.4.0
   - numpy
-  - numpy-base=1.15.0
+  - numpy-base
   - openssl=1.0.2p
   - pandas=0.23.4
   - parso=0.3.1

--- a/windows.yml
+++ b/windows.yml
@@ -61,7 +61,7 @@ dependencies:
   - xz=5.2.4
   - zlib=1.2.11
   - py-xgboost=0.72
-  - tqdm=4.15.0
+  - tqdm
   - statsmodels=0.9.0
   - beautifulsoup4=4.7.1
   - networkx=2.2


### PR DESCRIPTION
update environment files for windows and mac/linux. Most packages have explicit version numbers. Some of the supporting packages that we never actually directly touch (e.g. `mkl`) have purposefully had their version numbers left off, in order to let conda figure out which version it needs to satisfy the requirements for the top-level packages that we make use of directly (e.g. scikit-learn). 

Packages that conda had trouble finding/installing were moved to pip. When version numbers were left off, this was also an explicit choice in order to help things install more smoothly. 